### PR TITLE
Only use ASCII in the tests

### DIFF
--- a/test/Core.purs
+++ b/test/Core.purs
@@ -7,8 +7,8 @@ type Test = Effect (exception :: EXCEPTION, console :: CONSOLE) Unit
 (==>) :: forall a. (HasEqual a, HasShow a) => a -> a -> Test
 (==>) x y = if x == y
   then do
-    info ("✔︎ " + show x + " = " + show y)
+    info ("- PASS: " + show x + " = " + show y)
   else do
-    error ("✘ " + show x + " ≠ " + show y)
+    error ("- FAIL: " + show x + " ≠ " + show y)
     throw (exception "test failed")
 infix 0 ==>

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,4 +7,3 @@ import Test.Neon (testNeon)
 main :: Test
 main = do
   testNeon
-  info "✔︎ Tests passed."


### PR DESCRIPTION
This pull request fixes #19. It ditches the fancy check and cross marks in favor of plain ASCII descriptions. 
