### PR TITLE
Remove object equality

### DIFF
--- a/src/Neon/Types/HasEqual.purs
+++ b/src/Neon/Types/HasEqual.purs
@@ -10,7 +10,6 @@ foreign import nativeEqualChar :: Char -> Char -> Boolean
 foreign import nativeEqualFunction :: forall a b. (a -> b) -> (a -> b) -> Boolean
 foreign import nativeEqualInt :: Int -> Int -> Boolean
 foreign import nativeEqualNumber :: Number -> Number -> Boolean
-foreign import nativeEqualObject :: forall o. Object o -> Object o -> Boolean
 foreign import nativeEqualString :: String -> String -> Boolean
 
 -- | Laws:
@@ -37,9 +36,6 @@ instance intHasEqual :: HasEqual Int where
 
 instance numberHasEqual :: HasEqual Number where
   equal x y = nativeEqualNumber x y
-
-instance objectHasEqual :: HasEqual (Object o) where
-  equal x y = nativeEqualObject x y
 
 instance stringHasEqual :: HasEqual String where
   equal x y = nativeEqualString x y

--- a/src/Neon/Types/Native/HasEqual.js
+++ b/src/Neon/Types/Native/HasEqual.js
@@ -39,7 +39,5 @@ module.exports = {
 
   nativeEqualNumber: equalGeneric,
 
-  nativeEqualObject: equalGeneric,
-
   nativeEqualString: equalGeneric
 };

--- a/test/Neon/Types/HasEqual.purs
+++ b/test/Neon/Types/HasEqual.purs
@@ -14,5 +14,4 @@ testHasEqual = do
   f == f ==> true
   1 == 2 ==> false
   1.0 == 1.0 ==> true
-  { k: "a" } == { k: "z" } ==> false
   "neon" == "neon" ==> true


### PR DESCRIPTION
This pull request fixes #24. It removes the `HasEqual` instance for `Object` values. 
