### PR TITLE
Add more enumerable instances

### DIFF
--- a/src/Neon/Types/IsEnumerable.purs
+++ b/src/Neon/Types/IsEnumerable.purs
@@ -60,23 +60,19 @@ instance intIsEnumerable :: IsEnumerable Int where
   pred x = if x == bottom then Nothing else Just (x - 1)
 
 instance maybeIsEnumerable :: (IsEnumerable a) => IsEnumerable (Maybe a) where
-  -- fromEnum :: Maybe a -> Int
   fromEnum x = case x of
     Nothing -> 0
     Just j -> 1 + fromEnum j
-  -- toEnum :: Int -> Maybe (Maybe a)
   toEnum x = case x of
     0 -> Just Nothing
     _ -> case toEnum (x - 1) of
       Nothing -> Nothing
       Just j -> Just (Just j)
-  -- succ :: Maybe a -> Maybe (Maybe a)
   succ x = case x of
     Nothing -> Just bottom
     Just j -> case succ j of
       Nothing -> Nothing
       Just k -> Just (Just k)
-  -- pred :: Maybe a -> Maybe (Maybe a)
   pred x = case x of
     Nothing -> Nothing
     Just j -> Just (pred j)

--- a/src/Neon/Types/IsEnumerable.purs
+++ b/src/Neon/Types/IsEnumerable.purs
@@ -14,6 +14,7 @@ import Neon.Types.HasOr ((||))
 import Neon.Types.HasSubtract ((-))
 import Neon.Types.HasTop (HasTop, top)
 import Neon.Values.Maybe (Maybe(Nothing, Just))
+import Neon.Values.Ordering (Ordering(LessThan, EqualTo, GreaterThan))
 import Neon.Values.Unit (Unit(), unit)
 
 foreign import nativeFromEnumChar :: Char -> Int
@@ -76,6 +77,25 @@ instance maybeIsEnumerable :: (IsEnumerable a) => IsEnumerable (Maybe a) where
   pred x = case x of
     Nothing -> Nothing
     Just j -> Just (pred j)
+
+instance orderingIsEnumerable :: IsEnumerable Ordering where
+  fromEnum x = case x of
+    LessThan -> 0
+    EqualTo -> 1
+    GreaterThan -> 2
+  toEnum x = case x of
+    0 -> Just LessThan
+    1 -> Just EqualTo
+    2 -> Just GreaterThan
+    _ -> Nothing
+  succ x = case x of
+    LessThan -> Just EqualTo
+    EqualTo -> Just GreaterThan
+    _ -> Nothing
+  pred x = case x of
+    EqualTo -> Just LessThan
+    GreaterThan -> Just EqualTo
+    _ -> Nothing
 
 instance unitIsEnumerable :: IsEnumerable Unit where
   fromEnum _ = 0

--- a/src/Neon/Types/IsEnumerable.purs
+++ b/src/Neon/Types/IsEnumerable.purs
@@ -14,6 +14,7 @@ import Neon.Types.HasOr ((||))
 import Neon.Types.HasSubtract ((-))
 import Neon.Types.HasTop (HasTop, top)
 import Neon.Values.Maybe (Maybe(Nothing, Just))
+import Neon.Values.Unit (Unit(), unit)
 
 foreign import nativeFromEnumChar :: Char -> Int
 foreign import nativeToEnumChar :: Int -> Char
@@ -57,3 +58,9 @@ instance intIsEnumerable :: IsEnumerable Int where
   toEnum x = Just x
   succ x = if x == top then Nothing else Just (x + 1)
   pred x = if x == bottom then Nothing else Just (x - 1)
+
+instance unitIsEnumerable :: IsEnumerable Unit where
+  fromEnum _ = 0
+  toEnum x = if x == 0 then Just unit else Nothing
+  succ _ = Nothing
+  pred _ = Nothing

--- a/src/Neon/Types/IsEnumerable.purs
+++ b/src/Neon/Types/IsEnumerable.purs
@@ -6,9 +6,16 @@ module Neon.Types.IsEnumerable
   , pred
   ) where
 
-import Neon.Types.HasBottom (HasBottom)
-import Neon.Types.HasTop (HasTop)
+import Neon.Types.HasAdd ((+))
+import Neon.Types.HasBottom (HasBottom, bottom)
+import Neon.Types.HasCompare ((<), (>))
+import Neon.Types.HasOr ((||))
+import Neon.Types.HasSubtract ((-))
+import Neon.Types.HasTop (HasTop, top)
 import Neon.Values.Maybe (Maybe(Nothing, Just))
+
+foreign import nativeFromEnumChar :: Char -> Int
+foreign import nativeToEnumChar :: Int -> Char
 
 -- | Laws:
 -- | - `pred bottom = Nothing`
@@ -35,3 +42,11 @@ instance booleanIsEnumerable :: IsEnumerable Boolean where
   pred x = case x of
     false -> Nothing
     true -> Just true
+
+instance charIsEnumerable :: IsEnumerable Char where
+  fromEnum x = nativeFromEnumChar x
+  toEnum x = if x < fromEnum (bottom :: Char) || x > fromEnum (top :: Char)
+    then Nothing
+    else Just (nativeToEnumChar x)
+  succ x = toEnum (fromEnum x + 1)
+  pred x = toEnum (fromEnum x - 1)

--- a/src/Neon/Types/IsEnumerable.purs
+++ b/src/Neon/Types/IsEnumerable.purs
@@ -9,6 +9,7 @@ module Neon.Types.IsEnumerable
 import Neon.Types.HasAdd ((+))
 import Neon.Types.HasBottom (HasBottom, bottom)
 import Neon.Types.HasCompare ((<), (>))
+import Neon.Types.HasEqual ((==))
 import Neon.Types.HasOr ((||))
 import Neon.Types.HasSubtract ((-))
 import Neon.Types.HasTop (HasTop, top)
@@ -50,3 +51,9 @@ instance charIsEnumerable :: IsEnumerable Char where
     else Just (nativeToEnumChar x)
   succ x = toEnum (fromEnum x + 1)
   pred x = toEnum (fromEnum x - 1)
+
+instance intIsEnumerable :: IsEnumerable Int where
+  fromEnum x = x
+  toEnum x = Just x
+  succ x = if x == top then Nothing else Just (x + 1)
+  pred x = if x == bottom then Nothing else Just (x - 1)

--- a/src/Neon/Types/IsEnumerable.purs
+++ b/src/Neon/Types/IsEnumerable.purs
@@ -43,7 +43,7 @@ instance booleanIsEnumerable :: IsEnumerable Boolean where
     true -> Nothing
   pred x = case x of
     false -> Nothing
-    true -> Just true
+    true -> Just false
 
 instance charIsEnumerable :: IsEnumerable Char where
   fromEnum x = nativeFromEnumChar x
@@ -58,6 +58,28 @@ instance intIsEnumerable :: IsEnumerable Int where
   toEnum x = Just x
   succ x = if x == top then Nothing else Just (x + 1)
   pred x = if x == bottom then Nothing else Just (x - 1)
+
+instance maybeIsEnumerable :: (IsEnumerable a) => IsEnumerable (Maybe a) where
+  -- fromEnum :: Maybe a -> Int
+  fromEnum x = case x of
+    Nothing -> 0
+    Just j -> 1 + fromEnum j
+  -- toEnum :: Int -> Maybe (Maybe a)
+  toEnum x = case x of
+    0 -> Just Nothing
+    _ -> case toEnum (x - 1) of
+      Nothing -> Nothing
+      Just j -> Just (Just j)
+  -- succ :: Maybe a -> Maybe (Maybe a)
+  succ x = case x of
+    Nothing -> Just bottom
+    Just j -> case succ j of
+      Nothing -> Nothing
+      Just k -> Just (Just k)
+  -- pred :: Maybe a -> Maybe (Maybe a)
+  pred x = case x of
+    Nothing -> Nothing
+    Just j -> Just (pred j)
 
 instance unitIsEnumerable :: IsEnumerable Unit where
   fromEnum _ = 0

--- a/src/Neon/Types/Native/IsEnumerable.js
+++ b/src/Neon/Types/Native/IsEnumerable.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// module Neon.Types.IsEnumerable
+
+module.exports = {
+  nativeFromEnumChar: function (x) {
+    return x.charCodeAt(0);
+  },
+
+  nativeToEnumChar: function (x) {
+    return String.fromCharCode(x);
+  }
+};

--- a/src/Neon/Values/Identity.purs
+++ b/src/Neon/Values/Identity.purs
@@ -12,7 +12,7 @@ import Neon.Types.HasCompare (HasCompare, compare)
 import Neon.Types.HasDivide (HasDivide, (/), (%))
 import Neon.Types.HasEqual (HasEqual, (==))
 import Neon.Types.HasFold (HasFold)
-import Neon.Types.HasMap (HasMap)
+import Neon.Types.HasMap (HasMap, (<$>))
 import Neon.Types.HasMultiply (HasMultiply, (*))
 import Neon.Types.HasNot (HasNot, not)
 import Neon.Types.HasOne (HasOne, one)
@@ -22,6 +22,8 @@ import Neon.Types.HasShow (HasShow, show)
 import Neon.Types.HasSubtract (HasSubtract, (-))
 import Neon.Types.HasTop (HasTop, top)
 import Neon.Types.HasZero (HasZero, zero)
+import Neon.Types.IsEnumerable
+import Neon.Values.Maybe
 
 newtype Identity a = Identity a
 
@@ -83,6 +85,12 @@ instance identityHasTop :: (HasTop a) => HasTop (Identity a) where
 
 instance identityHasZero :: (HasZero a) => HasZero (Identity a) where
   zero = Identity zero
+
+instance identityIsEnumerable :: (IsEnumerable a) => IsEnumerable (Identity a) where
+  fromEnum (Identity x) = fromEnum x
+  toEnum x = Identity <$> toEnum x
+  succ (Identity x) = Identity <$> succ x
+  pred (Identity x) = Identity <$> pred x
 
 runIdentity :: forall a. Identity a -> a
 runIdentity (Identity x) = x

--- a/src/Neon/Values/Identity.purs
+++ b/src/Neon/Values/Identity.purs
@@ -22,8 +22,8 @@ import Neon.Types.HasShow (HasShow, show)
 import Neon.Types.HasSubtract (HasSubtract, (-))
 import Neon.Types.HasTop (HasTop, top)
 import Neon.Types.HasZero (HasZero, zero)
-import Neon.Types.IsEnumerable
-import Neon.Values.Maybe
+import Neon.Types.IsEnumerable (IsEnumerable, fromEnum, toEnum, succ, pred)
+import Neon.Values.Maybe (Maybe(Nothing, Just))
 
 newtype Identity a = Identity a
 

--- a/test/Neon/Types/IsEnumerable.purs
+++ b/test/Neon/Types/IsEnumerable.purs
@@ -7,19 +7,34 @@ import Test.Core (Test(), (==>))
 testIsEnumerable :: Test
 testIsEnumerable = do
   info "Neon.Types.IsEnumerable"
+
   fromEnum false ==> 0
   toEnum 1 ==> Just true
   succ false ==> Just true
   pred false ==> Nothing
+
   fromEnum 'A' ==> 65
   toEnum 65 ==> Just 'A'
   toEnum 999999999 ==> Nothing :: Maybe Char
   succ 'A' ==> Just 'B'
   pred 'B' ==> Just 'A'
+
   fromEnum 2 ==> 2
   toEnum 2 ==> Just 2
   succ 2 ==> Just 3
   pred 2 ==> Just 1
+
+  fromEnum (Nothing :: Maybe Boolean) ==> 0
+  fromEnum (Just true) ==> 2
+  toEnum 0 ==> Just (Nothing :: Maybe Boolean)
+  toEnum 1 ==> Just (Just false)
+  succ Nothing ==> Just (Nothing :: Maybe Boolean)
+  succ (Just false) ==> Just (Just true)
+  succ (Just true) ==> Nothing
+  pred Nothing ==> Nothing :: Maybe (Maybe Boolean)
+  pred (Just false) ==> Just Nothing
+  pred (Just true) ==> Just (Just false)
+
   fromEnum unit ==> 0
   toEnum 0 ==> Just unit
   succ unit ==> Nothing

--- a/test/Neon/Types/IsEnumerable.purs
+++ b/test/Neon/Types/IsEnumerable.purs
@@ -16,3 +16,7 @@ testIsEnumerable = do
   toEnum 999999999 ==> Nothing :: Maybe Char
   succ 'A' ==> Just 'B'
   pred 'B' ==> Just 'A'
+  fromEnum 2 ==> 2
+  toEnum 2 ==> Just 2
+  succ 2 ==> Just 3
+  pred 2 ==> Just 1

--- a/test/Neon/Types/IsEnumerable.purs
+++ b/test/Neon/Types/IsEnumerable.purs
@@ -20,3 +20,7 @@ testIsEnumerable = do
   toEnum 2 ==> Just 2
   succ 2 ==> Just 3
   pred 2 ==> Just 1
+  fromEnum unit ==> 0
+  toEnum 0 ==> Just unit
+  succ unit ==> Nothing
+  pred unit ==> Nothing

--- a/test/Neon/Types/IsEnumerable.purs
+++ b/test/Neon/Types/IsEnumerable.purs
@@ -35,6 +35,11 @@ testIsEnumerable = do
   pred (Just false) ==> Just Nothing
   pred (Just true) ==> Just (Just false)
 
+  fromEnum LessThan ==> 0
+  toEnum 1 ==> Just EqualTo
+  succ GreaterThan ==> Nothing
+  pred GreaterThan ==> Just EqualTo
+
   fromEnum unit ==> 0
   toEnum 0 ==> Just unit
   succ unit ==> Nothing

--- a/test/Neon/Types/IsEnumerable.purs
+++ b/test/Neon/Types/IsEnumerable.purs
@@ -11,3 +11,8 @@ testIsEnumerable = do
   toEnum 1 ==> Just true
   succ false ==> Just true
   pred false ==> Nothing
+  fromEnum 'A' ==> 65
+  toEnum 65 ==> Just 'A'
+  toEnum 999999999 ==> Nothing :: Maybe Char
+  succ 'A' ==> Just 'B'
+  pred 'B' ==> Just 'A'

--- a/test/Neon/Values/Identity.purs
+++ b/test/Neon/Values/Identity.purs
@@ -28,3 +28,7 @@ testIdentity = do
   Identity 3 - Identity 2 ==> Identity 1
   top ==> Identity true
   zero ==> Identity 0
+  fromEnum (Identity false) ==> 0
+  toEnum 0 ==> Just (Identity false)
+  succ (Identity false) ==> Just (Identity true)
+  pred (Identity true) ==> Just (Identity false)


### PR DESCRIPTION
Fixes #18. Still to do:
- [x] `Int`
- [x] `Ordering`
- [x] `Unit`
- [x] `Identity a`
- [x] `Maybe a`
- [ ] `Either a b`
- [ ] `Pair a b`
- [ ] `These a b`
