### PR TITLE
Add a class for comparing things

### DIFF
--- a/src/Neon/Class.purs
+++ b/src/Neon/Class.purs
@@ -4,6 +4,7 @@ module Neon.Class
   , module Neon.Class.HasApply
   , module Neon.Class.HasBottom
   , module Neon.Class.HasChain
+  , module Neon.Class.HasCompare
   , module Neon.Class.HasDivide
   , module Neon.Class.HasEqual
   , module Neon.Class.HasFilter
@@ -34,6 +35,7 @@ import Neon.Class.HasAnd as Neon.Class.HasAnd
 import Neon.Class.HasApply as Neon.Class.HasApply
 import Neon.Class.HasBottom as Neon.Class.HasBottom
 import Neon.Class.HasChain as Neon.Class.HasChain
+import Neon.Class.HasCompare as Neon.Class.HasCompare
 import Neon.Class.HasDivide as Neon.Class.HasDivide
 import Neon.Class.HasEqual as Neon.Class.HasEqual
 import Neon.Class.HasFilter as Neon.Class.HasFilter

--- a/src/Neon/Class/HasAdd.purs
+++ b/src/Neon/Class/HasAdd.purs
@@ -18,5 +18,8 @@ instance listHasAdd :: HasAdd (Data.List a) where
 instance numberHasAdd :: HasAdd Number where
   add y x = Prelude.add x y
 
+instance orderingHasAdd :: HasAdd Data.Ordering where
+  add y x = Prelude.append x y
+
 instance stringHasAdd :: HasAdd String where
   add y x = Prelude.append x y

--- a/src/Neon/Class/HasBottom.purs
+++ b/src/Neon/Class/HasBottom.purs
@@ -1,5 +1,6 @@
 module Neon.Class.HasBottom where
 
+import Neon.Data as Data
 import Neon.Primitive as Primitive
 import Prelude as Prelude
 
@@ -17,3 +18,6 @@ instance intHasBottom :: HasBottom Int where
 
 instance numberHasBottom :: HasBottom Number where
   bottom = Prelude.negate Primitive.infinity
+
+instance orderingHasBottom :: HasBottom Data.Ordering where
+  bottom = Prelude.bottom

--- a/src/Neon/Class/HasCompare.purs
+++ b/src/Neon/Class/HasCompare.purs
@@ -1,11 +1,12 @@
 module Neon.Class.HasCompare where
 
+import Neon.Class.HasEqual as HasEqual
 import Neon.Class.HasFromArray as HasFromArray
 import Neon.Class.HasGreater as HasGreater
 import Neon.Class.HasLess as HasLess
 import Neon.Data as Data
 
-class HasCompare a where
+class (HasEqual.HasEqual a, HasGreater.HasGreater a, HasLess.HasLess a) <= HasCompare a where
   compare :: a -> a -> Data.Ordering
 
 instance arrayHasCompare :: (HasCompare a) => HasCompare (Array a) where

--- a/src/Neon/Class/HasCompare.purs
+++ b/src/Neon/Class/HasCompare.purs
@@ -36,6 +36,9 @@ instance listHasCompare :: (HasCompare a) => HasCompare (Data.List a) where
 instance numberHasCompare :: HasCompare Number where
   compare y x = defaultCompare y x
 
+instance orderingHasCompare :: HasCompare Data.Ordering where
+  compare y x = defaultCompare y x
+
 instance stringHasCompare :: HasCompare String where
   compare y x = defaultCompare y x
 

--- a/src/Neon/Class/HasCompare.purs
+++ b/src/Neon/Class/HasCompare.purs
@@ -1,4 +1,4 @@
-module Neon.Class.HasCompare where
+module Neon.Class.HasCompare (class HasCompare, compare) where
 
 import Neon.Class.HasEqual as HasEqual
 import Neon.Class.HasFromArray as HasFromArray

--- a/src/Neon/Class/HasCompare.purs
+++ b/src/Neon/Class/HasCompare.purs
@@ -1,0 +1,47 @@
+module Neon.Class.HasCompare where
+
+import Neon.Class.HasFromArray as HasFromArray
+import Neon.Class.HasGreater as HasGreater
+import Neon.Class.HasLess as HasLess
+import Neon.Data as Data
+
+class HasCompare a where
+  compare :: a -> a -> Data.Ordering
+
+instance arrayHasCompare :: (HasCompare a) => HasCompare (Array a) where
+  compare y x =
+    let toList = HasFromArray.fromArray :: Array a -> Data.List a
+    in  compare (toList y) (toList x)
+
+instance booleanHasCompare :: HasCompare Boolean where
+  compare y x = defaultCompare y x
+
+instance charHasCompare :: HasCompare Char where
+  compare y x = defaultCompare y x
+
+instance intHasCompare :: HasCompare Int where
+  compare y x = defaultCompare y x
+
+instance listHasCompare :: (HasCompare a) => HasCompare (Data.List a) where
+  compare ys xs = case { xs: xs, ys: ys } of
+    { xs: Data.Nil, ys: Data.Nil } -> Data.EQ
+    { xs: Data.Nil, ys: Data.Cons _ _ } -> Data.LT
+    { xs: Data.Cons _ _, ys: Data.Nil } -> Data.GT
+    { xs: Data.Cons xh xt, ys: Data.Cons yh yt } -> case compare yh xh of
+      Data.EQ -> compare yt xt
+      Data.GT -> Data.GT
+      Data.LT -> Data.LT
+
+instance numberHasCompare :: HasCompare Number where
+  compare y x = defaultCompare y x
+
+instance stringHasCompare :: HasCompare String where
+  compare y x = defaultCompare y x
+
+defaultCompare :: forall a. (HasGreater.HasGreater a, HasLess.HasLess a) => a -> a -> Data.Ordering
+defaultCompare y x =
+  if HasGreater.greater y x
+    then Data.GT
+    else if HasLess.less y x
+      then Data.LT
+      else Data.EQ

--- a/src/Neon/Class/HasEqual.purs
+++ b/src/Neon/Class/HasEqual.purs
@@ -31,6 +31,9 @@ instance listHasEqual :: (HasEqual a) => HasEqual (Data.List a) where
 instance numberHasEqual :: HasEqual Number where
   equal y x = Prelude.eq x y
 
+instance orderingHasEqual :: HasEqual Data.Ordering where
+  equal y x = Prelude.eq x y
+
 instance stringHasEqual :: HasEqual String where
   equal y x = Prelude.eq x y
 

--- a/src/Neon/Class/HasFromInt.purs
+++ b/src/Neon/Class/HasFromInt.purs
@@ -14,3 +14,10 @@ instance charHasFromInt :: HasFromInt Char where
 
 instance intHasFromInt :: HasFromInt Int where
   fromInt x = Data.Just x
+
+instance orderingHasFromInt :: HasFromInt Data.Ordering where
+  fromInt x = case x of
+    0 -> Data.Just Data.LT
+    1 -> Data.Just Data.EQ
+    2 -> Data.Just Data.GT
+    _ -> Data.Nothing

--- a/src/Neon/Class/HasGreater.purs
+++ b/src/Neon/Class/HasGreater.purs
@@ -33,5 +33,8 @@ instance listHasGreater :: (HasEqual.HasEqual a, HasGreater a) => HasGreater (Da
 instance numberHasGreater :: HasGreater Number where
   greater y x = x Prelude.> y
 
+instance orderingHasGreater :: HasGreater Data.Ordering where
+  greater y x = x Prelude.> y
+
 instance stringHasGreater :: HasGreater String where
   greater y x = x Prelude.> y

--- a/src/Neon/Class/HasInspect.purs
+++ b/src/Neon/Class/HasInspect.purs
@@ -43,6 +43,9 @@ instance objectHasInspect :: HasInspect { | a } where
 instance orderingHasInspect :: HasInspect Data.Ordering where
   inspect x = Prelude.show x
 
+instance proxyHasInspect :: HasInspect (Data.Proxy a) where
+  inspect _ = "Proxy"
+
 instance stringHasInspect :: HasInspect String where
   inspect x = Prelude.show x
 

--- a/src/Neon/Class/HasInspect.purs
+++ b/src/Neon/Class/HasInspect.purs
@@ -40,6 +40,9 @@ instance numberHasInspect :: HasInspect Number where
 instance objectHasInspect :: HasInspect { | a } where
   inspect _ = "{- Object -}"
 
+instance orderingHasInspect :: HasInspect Data.Ordering where
+  inspect x = Prelude.show x
+
 instance stringHasInspect :: HasInspect String where
   inspect x = Prelude.show x
 

--- a/src/Neon/Class/HasLess.purs
+++ b/src/Neon/Class/HasLess.purs
@@ -33,5 +33,8 @@ instance listHasLess :: (HasEqual.HasEqual a, HasLess a) => HasLess (Data.List a
 instance numberHasLess :: HasLess Number where
   less y x = x Prelude.< y
 
+instance orderingHasLess :: HasLess Data.Ordering where
+  less y x = x Prelude.< y
+
 instance stringHasLess :: HasLess String where
   less y x = x Prelude.< y

--- a/src/Neon/Class/HasToInt.purs
+++ b/src/Neon/Class/HasToInt.purs
@@ -1,6 +1,7 @@
 module Neon.Class.HasToInt where
 
 import Data.Enum as Enum
+import Neon.Data as Data
 
 class HasToInt a where
   toInt :: a -> Int
@@ -13,3 +14,9 @@ instance charHasToInt :: HasToInt Char where
 
 instance intHasToInt :: HasToInt Int where
   toInt x = x
+
+instance orderingHasToInt :: HasToInt Data.Ordering where
+  toInt x = case x of
+    Data.LT -> 0
+    Data.EQ -> 1
+    Data.GT -> 2

--- a/src/Neon/Class/HasTop.purs
+++ b/src/Neon/Class/HasTop.purs
@@ -1,5 +1,6 @@
 module Neon.Class.HasTop where
 
+import Neon.Data as Data
 import Neon.Primitive as Primitive
 import Prelude as Prelude
 
@@ -17,3 +18,6 @@ instance intHasTop :: HasTop Int where
 
 instance numberHasTop :: HasTop Number where
   top = Primitive.infinity
+
+instance orderingHasTop :: HasTop Data.Ordering where
+  top = Prelude.top

--- a/src/Neon/Data.purs
+++ b/src/Neon/Data.purs
@@ -7,7 +7,8 @@ import Control.Monad.Eff.Exception (Error) as Export
 import Data.List (List(Nil, Cons)) as Export
 import Data.Maybe (Maybe(Nothing, Just)) as Export
 import Data.Tuple (Tuple(Tuple)) as Export
-import Prelude (Unit, unit) as Export
+import Prelude (Ordering(EQ, GT, LT), Unit, unit) as Export
+import Type.Proxy (Proxy(Proxy)) as Export
 
 import Control.Monad.Eff.Exception as Exception
 

--- a/test/Helper.purs
+++ b/test/Helper.purs
@@ -3,8 +3,10 @@ module Test.Helper
   , module Export
   ) where
 
+import Control.Monad.Aff (Aff) as Export
 import Prelude (bind) as Export
 import Test.QuickCheck ((===)) as Export
+import Test.QuickCheck.Arbitrary (class Arbitrary) as Export
 import Test.Unit (runTest, test) as Export
 import Test.Unit.Assert (assert) as Export
 import Test.Unit.QuickCheck (quickCheck) as Export
@@ -13,12 +15,9 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Random (RANDOM)
-import Prelude (Unit, bind)
-import Test.QuickCheck ((===))
-import Test.Unit (TIMER, runTest, test)
-import Test.Unit.Assert (assert)
+import Prelude (Unit)
+import Test.Unit (TIMER)
 import Test.Unit.Console (TESTOUTPUT)
-import Test.Unit.QuickCheck (quickCheck)
 
 type Test a = a
   ( avar :: AVAR

--- a/test/Neon/Class/HasAddTest.purs
+++ b/test/Neon/Class/HasAddTest.purs
@@ -18,6 +18,9 @@ suite = test "HasAdd" do
   test "Number" do
     quickCheck \ (x :: Number) y ->
       Neon.add y x === Prelude.add x y
+  test "Ordering" do
+    quickCheck \ (x :: Neon.Ordering) y ->
+      Neon.add y x === Prelude.append x y
   test "String" do
     quickCheck \ (x :: String) y ->
       Neon.add y x === Prelude.append x y

--- a/test/Neon/Class/HasBottomTest.purs
+++ b/test/Neon/Class/HasBottomTest.purs
@@ -19,3 +19,6 @@ suite = test "HasBottom" do
   test "Number" do
     assert "Prelude.negate Global.infinity"
       (Neon.equal (Neon.bottom :: Number) (Prelude.negate Global.infinity))
+  test "Ordering" do
+    assert "Prelude.bottom"
+      (Neon.equal (Neon.bottom :: Neon.Ordering) Prelude.bottom)

--- a/test/Neon/Class/HasCompareTest.purs
+++ b/test/Neon/Class/HasCompareTest.purs
@@ -22,5 +22,7 @@ suite = test "HasCompare" do
     qc (Neon.Proxy :: Neon.Proxy (Neon.List Int))
   test "Number" do
     qc (Neon.Proxy :: Neon.Proxy Number)
+  test "Ordering" do
+    qc (Neon.Proxy :: Neon.Proxy Neon.Ordering)
   test "String" do
     qc (Neon.Proxy :: Neon.Proxy String)

--- a/test/Neon/Class/HasCompareTest.purs
+++ b/test/Neon/Class/HasCompareTest.purs
@@ -1,0 +1,26 @@
+module Test.Neon.Class.HasCompareTest where
+
+import Neon as Neon
+import Prelude as Prelude
+import Test.Helper (Aff, class Arbitrary, Suite, Test, bind, quickCheck, test, (===))
+
+suite :: Suite
+suite = test "HasCompare" do
+  let qc :: forall a. (Arbitrary a, Neon.HasCompare a, Prelude.Ord a) => Neon.Proxy a -> Test Aff
+      qc _ = quickCheck \ (x :: a) y ->
+        Neon.compare y x === Prelude.compare x y
+
+  test "Array" do
+    qc (Neon.Proxy :: Neon.Proxy (Array Int))
+  test "Boolean" do
+    qc (Neon.Proxy :: Neon.Proxy Boolean)
+  test "Char" do
+    qc (Neon.Proxy :: Neon.Proxy Char)
+  test "Int" do
+    qc (Neon.Proxy :: Neon.Proxy Int)
+  test "List" do
+    qc (Neon.Proxy :: Neon.Proxy (Neon.List Int))
+  test "Number" do
+    qc (Neon.Proxy :: Neon.Proxy Number)
+  test "String" do
+    qc (Neon.Proxy :: Neon.Proxy String)

--- a/test/Neon/Class/HasEqualTest.purs
+++ b/test/Neon/Class/HasEqualTest.purs
@@ -24,6 +24,9 @@ suite = test "HasEqual" do
   test "Number" do
     quickCheck \ (x :: Number) y ->
       Neon.equal y x === Prelude.eq x y
+  test "Ordering" do
+    quickCheck \ (x :: Neon.Ordering) y ->
+      Neon.equal y x === Prelude.eq x y
   test "String" do
     quickCheck \ (x :: String) y ->
       Neon.equal y x === Prelude.eq x y

--- a/test/Neon/Class/HasFromIntTest.purs
+++ b/test/Neon/Class/HasFromIntTest.purs
@@ -16,3 +16,4 @@ suite = test "HasFromInt" do
   test "Int" do
     quickCheck \ x ->
       (Neon.fromInt x :: Neon.Maybe Int) === Neon.Just x
+  -- test "Ordering"

--- a/test/Neon/Class/HasGreaterTest.purs
+++ b/test/Neon/Class/HasGreaterTest.purs
@@ -24,6 +24,9 @@ suite = test "HasGreater" do
   test "Number" do
     quickCheck \ (x :: Number) y ->
       Neon.greater y x === x Prelude.> y
+  test "Ordering" do
+    quickCheck \ (x :: Neon.Ordering) y ->
+      Neon.greater y x === x Prelude.> y
   test "String" do
     quickCheck \ (x :: String) y ->
       Neon.greater y x === x Prelude.> y

--- a/test/Neon/Class/HasInspectTest.purs
+++ b/test/Neon/Class/HasInspectTest.purs
@@ -25,6 +25,9 @@ suite = test "HasInspect" do
   test "Number" do
     quickCheck \ (x :: Number) ->
       Neon.inspect x === Prelude.show x
+  test "Ordering" do
+    quickCheck \ (x :: Neon.Ordering) ->
+      Neon.inspect x === Prelude.show x
   test "String" do
     quickCheck \ (x :: String) ->
       Neon.inspect x === Prelude.show x

--- a/test/Neon/Class/HasInspectTest.purs
+++ b/test/Neon/Class/HasInspectTest.purs
@@ -2,7 +2,7 @@ module Test.Neon.Class.HasInspectTest where
 
 import Neon as Neon
 import Prelude as Prelude
-import Test.Helper (Suite, bind, quickCheck, test, (===))
+import Test.Helper (Suite, assert, bind, quickCheck, test, (===))
 
 suite :: Suite
 suite = test "HasInspect" do
@@ -28,6 +28,9 @@ suite = test "HasInspect" do
   test "Ordering" do
     quickCheck \ (x :: Neon.Ordering) ->
       Neon.inspect x === Prelude.show x
+  test "Proxy" do
+    assert "is \"Proxy\""
+      (Neon.equal (Neon.inspect (Neon.Proxy :: Neon.Proxy Int)) "Proxy")
   test "String" do
     quickCheck \ (x :: String) ->
       Neon.inspect x === Prelude.show x

--- a/test/Neon/Class/HasLessTest.purs
+++ b/test/Neon/Class/HasLessTest.purs
@@ -24,6 +24,9 @@ suite = test "HasLess" do
   test "Number" do
     quickCheck \ (x :: Number) y ->
       Neon.less y x === x Prelude.< y
+  test "Ordering" do
+    quickCheck \ (x :: Neon.Ordering) y ->
+      Neon.less y x === x Prelude.< y
   test "String" do
     quickCheck \ (x :: String) y ->
       Neon.less y x === x Prelude.< y

--- a/test/Neon/Class/HasToIntTest.purs
+++ b/test/Neon/Class/HasToIntTest.purs
@@ -15,3 +15,4 @@ suite = test "HasToInt" do
   test "Int" do
     quickCheck \ (x :: Int) ->
       Neon.toInt x === x
+  -- test "Ordering"

--- a/test/Neon/Class/HasTopTest.purs
+++ b/test/Neon/Class/HasTopTest.purs
@@ -19,3 +19,6 @@ suite = test "HasTop" do
   test "Number" do
     assert "Prelude.negate Global.infinity"
       (Neon.equal (Neon.top :: Number) Global.infinity)
+  test "Ordering" do
+    assert "Prelude.top"
+      (Neon.equal (Neon.top :: Neon.Ordering) Prelude.top)

--- a/test/Neon/ClassTest.purs
+++ b/test/Neon/ClassTest.purs
@@ -5,6 +5,7 @@ import Test.Neon.Class.HasAndTest as HasAndTest
 import Test.Neon.Class.HasApplyTest as HasApplyTest
 import Test.Neon.Class.HasBottomTest as HasBottomTest
 import Test.Neon.Class.HasChainTest as HasChainTest
+import Test.Neon.Class.HasCompareTest as HasCompareTest
 import Test.Neon.Class.HasDivideTest as HasDivideTest
 import Test.Neon.Class.HasEqualTest as HasEqualTest
 import Test.Neon.Class.HasFilterTest as HasFilterTest
@@ -37,6 +38,7 @@ suite = test "Class" do
   HasApplyTest.suite
   HasBottomTest.suite
   HasChainTest.suite
+  HasCompareTest.suite
   HasDivideTest.suite
   HasEqualTest.suite
   HasFilterTest.suite


### PR DESCRIPTION
This fixes #93.

I still have a few things to do here:
- [x] Consider not exporting `defaultCompare`. Maybe this should wait until #92 is resolved. 
- [x] Add instances for `Ordering` data type. 
- [x] Add instances for `Proxy` data type. 
